### PR TITLE
Upgrade to SBT 1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
-initialCommands in console := """import ai.faculty.sbt._"""
+console / initialCommands := """import ai.faculty.sbt._"""
 
 enablePlugins(ScriptedPlugin)
 // set up 'scripted; sbt plugin for testing sbt plugins

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := """sbt-houserules"""
 organization := "ai.faculty"
-version := "0.1.4-SNAPSHOT"
+version := "0.1.4"
 
 sbtPlugin := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.3

--- a/src/main/scala/ai/faculty/sbt/IntegrationTestSettingsPlugin.scala
+++ b/src/main/scala/ai/faculty/sbt/IntegrationTestSettingsPlugin.scala
@@ -10,9 +10,9 @@ object IntegrationTestSettingsPlugin extends AutoPlugin {
   override def requires = JvmPlugin
 
   override lazy val projectSettings = Defaults.itSettings ++ Seq(
-    scalaSource in IntegrationTest := baseDirectory.value / "it",
-    resourceDirectory in IntegrationTest := baseDirectory.value / "it" / "resources",
-    fork in IntegrationTest := true
+    IntegrationTest / scalaSource  := baseDirectory.value / "it",
+    IntegrationTest / resourceDirectory  := baseDirectory.value / "it" / "resources",
+    IntegrationTest / fork  := true
   )
 
   override lazy val projectConfigurations = Seq(IntegrationTest)

--- a/src/main/scala/ai/faculty/sbt/ScaladocSettingsPlugin.scala
+++ b/src/main/scala/ai/faculty/sbt/ScaladocSettingsPlugin.scala
@@ -12,6 +12,6 @@ object ScaladocSettingsPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     // We're unsetting all sources for the docs task because we don't want to
     // have scaladoc output in the build artifact
-    sources in (Compile, doc) := Seq.empty
+    Compile / doc / sources := Seq.empty
   )
 }

--- a/src/main/scala/ai/faculty/sbt/ScalastylePlugin.scala
+++ b/src/main/scala/ai/faculty/sbt/ScalastylePlugin.scala
@@ -21,13 +21,11 @@ object ScalastylePlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val projectSettings = Seq(
-    compileScalastyle := scalastyle.in(Compile).toTask("").value,
-    (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value,
-    testScalastyle := scalastyle.in(Test).toTask("").value,
-    (test in Test) := ((test in Test) dependsOn testScalastyle).value,
+    compileScalastyle := (Compile / scalastyle).toTask("").value,
+    Compile / compile := ((Compile / compile) dependsOn compileScalastyle).value,
+    testScalastyle := (Test / scalastyle).toTask("").value,
+    Test / test := ((Test / test) dependsOn testScalastyle).value,
     scalastyleConfigUrl := Some(getClass.getResource("/scalastyle-config.xml")),
-    (scalastyleConfigUrl in Test) := Some(
-      getClass.getResource("/scalastyle-config.xml")
-    )
+    Test / scalastyleConfigUrl := Some(getClass.getResource("/scalastyle-config.xml"))
   )
 }

--- a/src/main/scala/ai/faculty/sbt/UnitTestSettingsPlugin.scala
+++ b/src/main/scala/ai/faculty/sbt/UnitTestSettingsPlugin.scala
@@ -10,6 +10,6 @@ object UnitTestSettingsPlugin extends AutoPlugin {
   override def requires = JvmPlugin
 
   override lazy val projectSettings = Seq(
-    fork in Test := true
+    Test / fork := true
   )
 }


### PR DESCRIPTION
This PR has no effect on users, it only makes internal changes to make future development smoother by:

- using newer SBT (e.g. to be able to use [scala-3-migrate](https://github.com/scalacenter/scala3-migrate) to check Scala 3 comatibility)
- removing deprecated 0.13-style syntax